### PR TITLE
Add Cache Statistics support for multiple collections in Solr.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,10 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <debug>true</debug>
+                       <debuglevel>lines,vars,source</debuglevel>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/solrmeter/src/main/java/com/plugtree/solrmeter/model/statistic/AbstractStatisticConnection.java
+++ b/solrmeter/src/main/java/com/plugtree/solrmeter/model/statistic/AbstractStatisticConnection.java
@@ -39,7 +39,7 @@ public abstract class AbstractStatisticConnection {
 	public final static String CUMULATIVE_QUERY_RESULT_CACHE_NAME = "cumulativeQueryResultCache";
 	
 
-	public abstract Map<String, CacheData> getData() throws StatisticConnectionException;
+	public abstract Map<String, Map<String, CacheData>> getData() throws StatisticConnectionException;
 	
 	public CacheData getFilterCacheData(Map<String, CacheData> map) {
 		return map.get(FILTER_CACHE_NAME);

--- a/solrmeter/src/main/java/com/plugtree/solrmeter/model/statistic/CacheData.java
+++ b/solrmeter/src/main/java/com/plugtree/solrmeter/model/statistic/CacheData.java
@@ -102,5 +102,54 @@ public class CacheData {
 	public void setWarmupTime(long warmupTime) {
 		this.warmupTime = warmupTime;
 	}
+
+	@Override
+	public String toString() {
+		return "CacheData [lookups=" + lookups + ", hits=" + hits
+				+ ", hitratio=" + hitratio + ", inserts=" + inserts
+				+ ", evictions=" + evictions + ", size=" + size
+				+ ", warmupTime=" + warmupTime + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (int) (evictions ^ (evictions >>> 32));
+		result = prime * result + Float.floatToIntBits(hitratio);
+		result = prime * result + (int) (hits ^ (hits >>> 32));
+		result = prime * result + (int) (inserts ^ (inserts >>> 32));
+		result = prime * result + (int) (lookups ^ (lookups >>> 32));
+		result = prime * result + (int) (size ^ (size >>> 32));
+		result = prime * result + (int) (warmupTime ^ (warmupTime >>> 32));
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CacheData other = (CacheData) obj;
+		if (evictions != other.evictions)
+			return false;
+		if (Float.floatToIntBits(hitratio) != Float
+				.floatToIntBits(other.hitratio))
+			return false;
+		if (hits != other.hits)
+			return false;
+		if (inserts != other.inserts)
+			return false;
+		if (lookups != other.lookups)
+			return false;
+		if (size != other.size)
+			return false;
+		if (warmupTime != other.warmupTime)
+			return false;
+		return true;
+	}
 	
 }

--- a/solrmeter/src/test/java/com/plugtree/solrmeter/mock/MockStatisticConnection.java
+++ b/solrmeter/src/test/java/com/plugtree/solrmeter/mock/MockStatisticConnection.java
@@ -28,19 +28,24 @@ import com.plugtree.solrmeter.model.statistic.CacheData;
  */
 public class MockStatisticConnection extends AbstractStatisticConnection {
 	
-	private Map<String, CacheData> data;
+	private Map<String, Map<String, CacheData>> data;
+	private Map<String, CacheData> internalData;
+	
+	private String singleCollection = "SINGLE_COLLECTION";
 	
 	public MockStatisticConnection() {
 		super();
-		this.data = new HashMap<String, CacheData>();
+		this.data = new HashMap<>();
+		this.internalData = new HashMap<>();
+		this.data.put(singleCollection, internalData);
 	}
 	
 	public void putData(String key, CacheData cacheData) {
-		data.put(key, cacheData);
+		data.get(singleCollection).put(key, cacheData);
 	}
 
 	@Override
-	public Map<String, CacheData> getData() throws StatisticConnectionException {
+	public Map<String, Map<String, CacheData>> getData() throws StatisticConnectionException {
 		return data;
 	}
 

--- a/solrmeter/src/test/java/com/plugtree/solrmeter/statistic/RequestHandlerConnectionTestCase.java
+++ b/solrmeter/src/test/java/com/plugtree/solrmeter/statistic/RequestHandlerConnectionTestCase.java
@@ -1,6 +1,7 @@
 package com.plugtree.solrmeter.statistic;
 
 import java.net.MalformedURLException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrServer;
@@ -13,11 +14,14 @@ import com.plugtree.solrmeter.model.statistic.CacheData;
 import com.plugtree.solrmeter.model.statistic.RequestHandlerConnection;
 
 public class RequestHandlerConnectionTestCase extends BaseTestCase {
+	private static String dummyCollection = "SINGLE_COLLECTION";
 	
 	public void testConnectionData() throws MalformedURLException, StatisticConnectionException {
 		SolrServer solrServer = this.createMockSolrServer();
-		RequestHandlerConnection connection = new RequestHandlerConnection(solrServer);
-		Map<String, CacheData> data = connection.getData();
+		Map<String, SolrServer> serverMap = new HashMap<>();
+		serverMap.put(dummyCollection, solrServer);
+		RequestHandlerConnection connection = new RequestHandlerConnection(serverMap);
+		Map<String, CacheData> data = connection.getData().get(dummyCollection);
 		CacheData filterQueryData = connection.getFilterCacheData(data);
 		assertEquals((long)10, filterQueryData.getLookups());
 		assertEquals((long)5, filterQueryData.getHits());
@@ -29,8 +33,11 @@ public class RequestHandlerConnectionTestCase extends BaseTestCase {
 	
 	public void testAllCachesPresent() throws MalformedURLException, StatisticConnectionException {
 		SolrServer solrServer = this.createMockSolrServer();
-		RequestHandlerConnection connection = new RequestHandlerConnection(solrServer);
-		Map<String, CacheData> data = connection.getData();
+		Map<String, SolrServer> serverMap = new HashMap<>();
+		serverMap.put(dummyCollection, solrServer);
+		RequestHandlerConnection connection = new RequestHandlerConnection(serverMap);
+		Map<String, CacheData> data = connection.getData().get(dummyCollection);
+
 		assertNotNull(connection.getFilterCacheData(data));
 		assertNotNull(connection.getDocumentCacheData(data));
 		assertNotNull(connection.getFieldValueCacheData(data));
@@ -51,8 +58,10 @@ public class RequestHandlerConnectionTestCase extends BaseTestCase {
 	 */
 	public void testCumulativeData() throws MalformedURLException, StatisticConnectionException {
 		SolrServer solrServer = this.createMockSolrServer();
-		RequestHandlerConnection connection = new RequestHandlerConnection(solrServer);
-		Map<String, CacheData> data = connection.getData();
+		Map<String, SolrServer> serverMap = new HashMap<>();
+		serverMap.put(dummyCollection, solrServer);
+		RequestHandlerConnection connection = new RequestHandlerConnection(serverMap);
+		Map<String, CacheData> data = connection.getData().get(dummyCollection);
 		CacheData filterQueryData = connection.getCumulativeFilterCacheData(data);
 		
 		assertEquals((long)100, filterQueryData.getLookups());
@@ -156,8 +165,11 @@ public class RequestHandlerConnectionTestCase extends BaseTestCase {
 	
 	 public void testMissingCaches() throws MalformedURLException, StatisticConnectionException {
 	    SolrServer solrServer = this.createMockSolrServer("filterCache");
-	    RequestHandlerConnection connection = new RequestHandlerConnection(solrServer);
-	    Map<String, CacheData> data = connection.getData();
+		Map<String, SolrServer> serverMap = new HashMap<>();
+		serverMap.put(dummyCollection, solrServer);
+		RequestHandlerConnection connection = new RequestHandlerConnection(serverMap);
+		Map<String, CacheData> data = connection.getData().get(dummyCollection);
+
 	    assertNotNull(connection.getFilterCacheData(data));
 	    assertNull(connection.getDocumentCacheData(data));
 	    assertNull(connection.getFieldValueCacheData(data));


### PR DESCRIPTION
This change applies to the Cache History Panel.  It allows viewing cache statistics for each collection in a Solr instance.  Currently, the feature can only be enabled by importing a configuration from a file.

To enable this feature, define a variable called solr.collection.names in the configuration file, entering the names of the collections in your Solr instance.  In the Cache History Panel, a combo box in the top left of the panel will appear with the list of collections populated.  Switching between each of the collections will update the associated cache statistics relevant to the collection.

![image](https://user-images.githubusercontent.com/10552383/32346529-079ca68c-bfe4-11e7-88da-1f5452f136b0.png)
